### PR TITLE
correct pg querybuilder dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "total5": "latest",
-    "querybujilderpg": "latest"
+    "querybuilderpg": "latest"
   },
   "scripts": {
     "start": "node index.js 8000",

--- a/pluginable/package.json
+++ b/pluginable/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "total5": "latest",
-    "querybujilderpg": "latest"
+    "querybuilderpg": "latest"
   },
   "scripts": {
     "start": "node index.js 8000",


### PR DESCRIPTION
The example apps depend on querybujilderpg (note the misplaced j) which is not installable. I suppose it's just a typo and should be querybuilderpg.